### PR TITLE
Add status code information to `Response`

### DIFF
--- a/lib/ns1/response/base.rb
+++ b/lib/ns1/response/base.rb
@@ -3,6 +3,12 @@ require 'delegate'
 module NS1
   module Response
     class Base < SimpleDelegator
+      attr_reader :status
+
+      def initialize(body, status)
+        @status = status
+        super(body)
+      end
     end
   end
 end

--- a/lib/ns1/transport/net_http.rb
+++ b/lib/ns1/transport/net_http.rb
@@ -29,9 +29,9 @@ module NS1
         body = JSON.parse(response.body)
         case response
         when Net::HTTPOK
-          NS1::Response::Success.new(body)
+          NS1::Response::Success.new(body, response.code.to_i)
         else
-          NS1::Response::Error.new(body)
+          NS1::Response::Error.new(body, response.code.to_i)
         end
       rescue JSON::ParserError
         raise NS1::Transport::ResponseParseError

--- a/spec/api/records_spec.rb
+++ b/spec/api/records_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe NS1::API::Records do
     it "requests GET /v1/zones/:zone/:domain/:type" do
       request = stub_api(:get, "/v1/zones/example.com/www.example.com/A")
 
-      client.record("example.com", "www.example.com", "A")
+      response = client.record("example.com", "www.example.com", "A")
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 
@@ -38,9 +39,10 @@ RSpec.describe NS1::API::Records do
       request = stub_api(:put, "/v1/zones/example.com/www.example.com/A")
                   .with(body: JSON.dump(expected_body))
 
-      client.create_record("example.com", "www.example.com", "A", { answers: [] })
+      response = client.create_record("example.com", "www.example.com", "A", { answers: [] })
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 
@@ -50,9 +52,10 @@ RSpec.describe NS1::API::Records do
       request = stub_api(:post, "/v1/zones/example.com/www.example.com/CNAME")
                   .with(body: JSON.dump(expected_body))
 
-      client.modify_record("example.com", "www.example.com", "CNAME", { use_client_subnet: false } )
+      response = client.modify_record("example.com", "www.example.com", "CNAME", { use_client_subnet: false } )
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 
@@ -60,9 +63,10 @@ RSpec.describe NS1::API::Records do
     it "requests DELETE /v1/zones/:zone/:domain/:type" do
       request = stub_api(:delete, "/v1/zones/example.com/www.example.com/CNAME")
 
-      client.delete_record("example.com", "www.example.com", "CNAME")
+      response = client.delete_record("example.com", "www.example.com", "CNAME")
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 end

--- a/spec/api/zones_spec.rb
+++ b/spec/api/zones_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe NS1::API::Zones do
     it "requests GET /v1/zones" do
       request = stub_api(:get, "/v1/zones/example.com")
 
-      client.zone("example.com")
+      response = client.zone("example.com")
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 
@@ -42,9 +43,10 @@ RSpec.describe NS1::API::Zones do
       request = stub_api(:put, "/v1/zones/example.com")
                   .with(body: JSON.dump(expected_body))
 
-      client.create_zone("example.com")
+      response = client.create_zone("example.com")
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 
@@ -54,9 +56,10 @@ RSpec.describe NS1::API::Zones do
       request = stub_api(:post, "/v1/zones/example.com")
                   .with(body: JSON.dump(expected_body))
 
-      client.modify_zone("example.com", ttl: 600)
+      response = client.modify_zone("example.com", ttl: 600)
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 
@@ -64,9 +67,10 @@ RSpec.describe NS1::API::Zones do
     it "requests DELETE /v1/zones/:zone" do
       request = stub_api(:delete, "/v1/zones/example.com")
 
-      client.delete_zone("example.com")
+      response = client.delete_zone("example.com")
 
       expect(request).to have_been_requested
+      expect(response.status).to eq 200
     end
   end
 end

--- a/spec/transport/net_http_spec.rb
+++ b/spec/transport/net_http_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe NS1::Transport::NetHttp do
       response = transport.request("GET", "/example")
 
       expect(response).to be_a NS1::Response::Success
+      expect(response.status).to eq 200
     end
 
     it "returns NS1::Response::Error on non-200 response" do
@@ -47,6 +48,7 @@ RSpec.describe NS1::Transport::NetHttp do
       response = transport.request("GET", "/example")
 
       expect(response).to be_a NS1::Response::Error
+      expect(response.status).to eq 400
     end
   end
 end


### PR DESCRIPTION
`Response#status` now returns the status code of the response as an
integer.